### PR TITLE
[lit-css] Expose StyleModule class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.1.1"></a>
+# [0.1.1](https://github.com/bashmish/lit-css/compare/v0.1.0...v0.1.1) (2018-10-19)
+
+
+### Features
+
+* expose StyleModule class ([09ff05f](https://github.com/bashmish/lit-css/commit/09ff05f))
+
+
+
 <a name="0.1.0"></a>
 # 0.1.0 (2018-10-14)
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 import css from './src/lit-css.js';
+import StyleModule from './src/StyleModule.js';
 
-export { css };
+export { css, StyleModule };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-css",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A tool to distribute styles via ES modules.",
   "license": "MIT",
   "author": "Mikhail Bashkirov <bashmish@gmail.com>",
+  "repository": "github:bashmish/lit-css",
   "main": "index.js",
   "devDependencies": {
     "@polymer/lit-element": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-css",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A tool to distribute styles via ES modules.",
   "license": "MIT",
   "author": "Mikhail Bashkirov <bashmish@gmail.com>",


### PR DESCRIPTION
This is helpful to check the type of your module to prevent users defining modules as just normal strings.