### PR TITLE
[lit-css] Exclude objects from deduping when not created with the literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.1.2"></a>
+## [0.1.2](https://github.com/bashmish/lit-css/compare/v0.1.1...v0.1.2) (2018-10-21)
+
+
+### Bug Fixes
+
+* exclude other objects from deduping ([b2a8951](https://github.com/bashmish/lit-css/commit/b2a8951))
+
+
+
 <a name="0.1.1"></a>
 # [0.1.1](https://github.com/bashmish/lit-css/compare/v0.1.0...v0.1.1) (2018-10-19)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-css",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-css",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A tool to distribute styles via ES modules.",
   "license": "MIT",
   "author": "Mikhail Bashkirov <bashmish@gmail.com>",

--- a/src/StyleModule.js
+++ b/src/StyleModule.js
@@ -9,7 +9,10 @@ export default class StyleModule {
   toString() {
     const flatPartsWhichContainOtherModules = this.__getFlatPartsWhichContainOtherModules();
     const dedupedParts = flatPartsWhichContainOtherModules.filter((part, index) => {
-      return flatPartsWhichContainOtherModules.indexOf(part) === index;
+      if (part instanceof StyleModule) {
+        return flatPartsWhichContainOtherModules.indexOf(part) === index;
+      }
+      return true;
     });
     const allParts = dedupedParts.reduce((array, part) => {
       if (part instanceof StyleModule) {

--- a/test/lit-css_test.js
+++ b/test/lit-css_test.js
@@ -37,5 +37,15 @@ describe('lit-css', () => {
       expect(css`${s1}${s2_2}`.toString()).to.equal('.c1{}.c2{}');
       expect(css`${s2_2}${s1}`.toString()).to.equal('.c2{}.c1{}');
     });
+
+    it('should not dedupe other objects besides the ones created with the literal', () => {
+      const clr = 'red';
+      const size = 1;
+      const s1 = css`.c1{color:${clr};font-size:${size}px;}`;
+      const s2 = css`.c2{color:${clr};font-size:${size}px;}`;
+      const style = css`${s1}${s2}${s1}.c3{color:${clr};font-size:${size}px;}.c4{color:${clr};font-size:${size}px;}`;
+      const content = 'color:red;font-size:1px;';
+      expect(style.toString()).to.equal(`.c1{${content}}.c2{${content}}.c3{${content}}.c4{${content}}`);
+    });
   });
 });


### PR DESCRIPTION
The idea of the `css` literal is to create an object which has a particular semantic meaning and can later be deduped. All other objects like just strings and numbers should be kept always, because they are mostly used in place of CSS property values and have different semantic meaning.