### PR TITLE
[lit-css] Validate foreign object type to improve DX (fixes #4)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
     "arrow-body-style": 0,
     "class-methods-use-this": 0,
     "no-underscore-dangle": 0,
+    "no-use-before-define": ["error", { "functions": false }],
     "import/extensions": 0
   },
   "overrides": [

--- a/packages/lit-css/src/StyleModule.js
+++ b/packages/lit-css/src/StyleModule.js
@@ -36,13 +36,37 @@ export default class StyleModule {
     this.__parts = this.__strings
       .slice(0, this.__lastIndex)
       .reduce((array, string, index) => {
-        array.push(string);
-        array.push(this.__values[index]);
-        if (this.__values[index] instanceof StyleModule) {
+        const value = this.__values[index];
+        if (value instanceof StyleModule) {
           this.__containsStyleModules = true;
+        } else if (isNotAllowedType(value)) {
+          throw TypeError(
+            `Type of the embedded value "${stringifyValue(value)}" `
+            + 'is not one of the allowed: "string", "number" or another lit-css.',
+          );
         }
+        array.push(string);
+        array.push(value);
         return array;
       }, []);
     this.__parts.push(this.__strings[this.__lastIndex]);
   }
+}
+
+function isNotAllowedType(value) {
+  return (
+    (typeof value !== 'string' && typeof value !== 'number')
+    || value !== value /* NaN check */ // eslint-disable-line no-self-compare
+  );
+}
+
+function stringifyValue(value) {
+  let str;
+  try {
+    str = `${value}`;
+  } catch (error) {
+    // thanks to Symbol not being able to simply work with `${Symbol()}`
+    str = value.toString();
+  }
+  return str;
 }

--- a/packages/lit-css/test/lit-css.spec.js
+++ b/packages/lit-css/test/lit-css.spec.js
@@ -55,4 +55,50 @@ describe('lit-css', () => {
       expect(style.toString()).to.equal(`.c1{${content}}.c2{${content}}.c3{${content}}.c4{${content}}`);
     });
   });
+
+  describe('foreign object type validation', () => {
+    const typeError = [
+      TypeError,
+      /^Type of the embedded value ".+" is not one of the allowed: "string", "number" or another lit-css\.$/s,
+    ];
+
+    it('allows strings', () => {
+      expect(css`.c{color:${'red'};}`.toString()).to.eql('.c{color:red;}');
+    });
+
+    it('allows numbers', () => {
+      expect(css`.c{font-size:${2}em;}`.toString()).to.eql('.c{font-size:2em;}');
+    });
+
+    it('forbids booleans', () => {
+      expect(() => css`.c{border:${true};}`).to.throw(...typeError);
+      expect(() => css`.c{border:${false};}`).to.throw(...typeError);
+    });
+
+    it('forbids null', () => {
+      expect(() => css`.c{border:${null};}`).to.throw(...typeError);
+    });
+
+    it('forbids undefined', () => {
+      expect(() => css`.c{border:${undefined};}`).to.throw(...typeError);
+    });
+
+    it('forbids NaN', () => {
+      expect(() => css`.c{border:${NaN};}`).to.throw(...typeError);
+    });
+
+    it('forbids symbols', () => {
+      expect(() => css`.c{border:${Symbol('foo')};}`).to.throw(...typeError);
+    });
+
+    it('forbids functions', () => {
+      const mixin = () => 'color:red;';
+      expect(() => css`.c{${mixin}}`).to.throw(...typeError);
+      expect(css`.c{${mixin()}}`.toString()).to.eql('.c{color:red;}');
+    });
+
+    it('forbids objects', () => {
+      expect(() => css`.c{${{}}}`).to.throw(...typeError);
+    });
+  });
 });


### PR DESCRIPTION
This PR aims at improving developer experience while creating styles.

One of the issues is described here: https://github.com/bashmish/lit-styles/issues/4
In short, if you are using `LitElement` with `lit-css` and you forget to call a function (which is supposed to return some styles, so it is sort of a mixin) in the expression then this function object will be stringified and will cause infinite loop in ShadyCSS.

Also we should just prevent the usage of any other types besides Number or String, because it does not make much sense to stringify any arbitrary type implicitly.